### PR TITLE
update crontab to reflect default setup

### DIFF
--- a/etc/cron/crontab.txt
+++ b/etc/cron/crontab.txt
@@ -1,6 +1,4 @@
 # m h  dom mon dow   command
-*/1 * * * * base=/home/pi/piLogger ; $base/bin/logAll $base/etc/capture.conf >/dev/null 2>&1 ; $base/bin/refreshCaches 12h ; $base/bin/refreshCaches sensors
-*/10 * * * * /home/pi/piLogger/bin/refreshCaches 24h 
-4 * * * * /home/pi/piLogger/bin/refreshCaches 48h
-5 */6 * * * /home/pi/piLogger/bin/refreshCaches 168h
-
+*/1 * * * *   base=/home/pi/piLogger ; $base/bin/logAll --db >/dev/null 2>&1 ; $base/bin/refreshCaches 12h ; $base/bin/refreshCaches sensors
+*/10 * * * *  /home/pi/piLogger/bin/refreshCaches 24h 
+5 */6 * * *   /home/pi/piLogger/bin/refreshCaches 168h


### PR DESCRIPTION
during the installation we setup a graph for 12h, 24h and 168h so we have to adjust the crontab not to do 48h refresh. in addition we want to use logAll --db instead of the capture.conf file.